### PR TITLE
Update and lock library versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
       time: "06:00"
     target-branch: "develop"
     open-pull-requests-limit: 10
+    versioning-strategy: increase

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier:fix": "prettier --write 'scripts/**/*.mjs' 'bin/**/*.mjs'"
   },
   "dependencies": {
-    "@swc/core": "^1.3.24",
+    "@swc/core": "^1.3.28",
     "@swc/helpers": "^0.4.14",
     "browserslist": "^4.21.4",
     "compression-webpack-plugin": "^10.0.0",
@@ -44,10 +44,10 @@
     "webpack-dev-server": "^4.11.1"
   },
   "devDependencies": {
-    "eslint": "^8.31.0",
+    "eslint": "^8.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.26.0",
-    "prettier": "^2.8.1"
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-import": "^2.27.5",
+    "prettier": "^2.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d-leb/swc-webpack",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "A library for compiling TypeScript and JavaScript using SWC and Webpack",
   "author": "David LeBlanc <github@david-leblanc.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,19 +29,19 @@
     "prettier:fix": "prettier --write 'scripts/**/*.mjs' 'bin/**/*.mjs'"
   },
   "dependencies": {
-    "@swc/core": "^1.3.28",
-    "@swc/helpers": "^0.4.14",
-    "browserslist": "^4.21.4",
-    "compression-webpack-plugin": "^10.0.0",
-    "cross-spawn": "^7.0.3",
-    "dotenv-webpack": "^8.0.1",
-    "html-webpack-plugin": "^5.5.0",
-    "imports-loader": "^4.0.1",
-    "svg-url-loader": "^8.0.0",
-    "swc-loader": "^0.2.3",
-    "webpack": "^5.75.0",
-    "webpack-bundle-analyzer": "^4.7.0",
-    "webpack-dev-server": "^4.11.1"
+    "@swc/core": "1.3.28",
+    "@swc/helpers": "0.4.14",
+    "browserslist": "4.21.4",
+    "compression-webpack-plugin": "10.0.0",
+    "cross-spawn": "7.0.3",
+    "dotenv-webpack": "8.0.1",
+    "html-webpack-plugin": "5.5.0",
+    "imports-loader": "4.0.1",
+    "svg-url-loader": "8.0.0",
+    "swc-loader": "0.2.3",
+    "webpack": "5.75.0",
+    "webpack-bundle-analyzer": "4.7.0",
+    "webpack-dev-server": "4.11.1"
   },
   "devDependencies": {
     "eslint": "^8.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,19 +9,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-leb/swc-webpack@workspace:."
   dependencies:
-    "@swc/core": ^1.3.24
+    "@swc/core": ^1.3.28
     "@swc/helpers": ^0.4.14
     browserslist: ^4.21.4
     compression-webpack-plugin: ^10.0.0
     cross-spawn: ^7.0.3
     dotenv-webpack: ^8.0.1
-    eslint: ^8.31.0
+    eslint: ^8.32.0
     eslint-config-airbnb-base: ^15.0.0
-    eslint-config-prettier: ^8.5.0
-    eslint-plugin-import: ^2.26.0
+    eslint-config-prettier: ^8.6.0
+    eslint-plugin-import: ^2.27.5
     html-webpack-plugin: ^5.5.0
     imports-loader: ^4.0.1
-    prettier: ^2.8.1
+    prettier: ^2.8.3
     svg-url-loader: ^8.0.0
     swc-loader: ^0.2.3
     webpack: ^5.75.0
@@ -264,7 +264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.24":
+"@swc/core@npm:^1.3.28":
   version: 1.3.28
   resolution: "@swc/core@npm:1.3.28"
   dependencies:
@@ -1758,7 +1758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^8.5.0":
+"eslint-config-prettier@npm:^8.6.0":
   version: 8.6.0
   resolution: "eslint-config-prettier@npm:8.6.0"
   peerDependencies:
@@ -1792,7 +1792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.26.0":
+"eslint-plugin-import@npm:^2.27.5":
   version: 2.27.5
   resolution: "eslint-plugin-import@npm:2.27.5"
   dependencies:
@@ -1862,7 +1862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.31.0":
+"eslint@npm:^8.32.0":
   version: 8.32.0
   resolution: "eslint@npm:8.32.0"
   dependencies:
@@ -3734,7 +3734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.8.1":
+"prettier@npm:^2.8.3":
   version: 2.8.3
   resolution: "prettier@npm:2.8.3"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,24 +9,24 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@d-leb/swc-webpack@workspace:."
   dependencies:
-    "@swc/core": ^1.3.28
-    "@swc/helpers": ^0.4.14
-    browserslist: ^4.21.4
-    compression-webpack-plugin: ^10.0.0
-    cross-spawn: ^7.0.3
-    dotenv-webpack: ^8.0.1
+    "@swc/core": 1.3.28
+    "@swc/helpers": 0.4.14
+    browserslist: 4.21.4
+    compression-webpack-plugin: 10.0.0
+    cross-spawn: 7.0.3
+    dotenv-webpack: 8.0.1
     eslint: ^8.32.0
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-prettier: ^8.6.0
     eslint-plugin-import: ^2.27.5
-    html-webpack-plugin: ^5.5.0
-    imports-loader: ^4.0.1
+    html-webpack-plugin: 5.5.0
+    imports-loader: 4.0.1
     prettier: ^2.8.3
-    svg-url-loader: ^8.0.0
-    swc-loader: ^0.2.3
-    webpack: ^5.75.0
-    webpack-bundle-analyzer: ^4.7.0
-    webpack-dev-server: ^4.11.1
+    svg-url-loader: 8.0.0
+    swc-loader: 0.2.3
+    webpack: 5.75.0
+    webpack-bundle-analyzer: 4.7.0
+    webpack-dev-server: 4.11.1
   bin:
     swc-webpack: bin/swc-webpack.mjs
   languageName: unknown
@@ -264,7 +264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.3.28":
+"@swc/core@npm:1.3.28":
   version: 1.3.28
   resolution: "@swc/core@npm:1.3.28"
   dependencies:
@@ -303,7 +303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.4.14":
+"@swc/helpers@npm:0.4.14":
   version: 0.4.14
   resolution: "@swc/helpers@npm:0.4.14"
   dependencies:
@@ -1025,7 +1025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.14.5, browserslist@npm:^4.21.4":
+"browserslist@npm:4.21.4, browserslist@npm:^4.14.5":
   version: 4.21.4
   resolution: "browserslist@npm:4.21.4"
   dependencies:
@@ -1241,7 +1241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compression-webpack-plugin@npm:^10.0.0":
+"compression-webpack-plugin@npm:10.0.0":
   version: 10.0.0
   resolution: "compression-webpack-plugin@npm:10.0.0"
   dependencies:
@@ -1333,7 +1333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -1562,7 +1562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-webpack@npm:^8.0.1":
+"dotenv-webpack@npm:8.0.1":
   version: 8.0.1
   resolution: "dotenv-webpack@npm:8.0.1"
   dependencies:
@@ -2485,7 +2485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.5.0":
+"html-webpack-plugin@npm:5.5.0":
   version: 5.5.0
   resolution: "html-webpack-plugin@npm:5.5.0"
   dependencies:
@@ -2659,7 +2659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"imports-loader@npm:^4.0.1":
+"imports-loader@npm:4.0.1":
   version: 4.0.1
   resolution: "imports-loader@npm:4.0.1"
   dependencies:
@@ -4432,7 +4432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svg-url-loader@npm:^8.0.0":
+"svg-url-loader@npm:8.0.0":
   version: 8.0.0
   resolution: "svg-url-loader@npm:8.0.0"
   dependencies:
@@ -4443,7 +4443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swc-loader@npm:^0.2.3":
+"swc-loader@npm:0.2.3":
   version: 0.2.3
   resolution: "swc-loader@npm:0.2.3"
   peerDependencies:
@@ -4708,7 +4708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.7.0":
+"webpack-bundle-analyzer@npm:4.7.0":
   version: 4.7.0
   resolution: "webpack-bundle-analyzer@npm:4.7.0"
   dependencies:
@@ -4742,7 +4742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^4.11.1":
+"webpack-dev-server@npm:4.11.1":
   version: 4.11.1
   resolution: "webpack-dev-server@npm:4.11.1"
   dependencies:
@@ -4793,7 +4793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.75.0":
+"webpack@npm:5.75.0":
   version: 5.75.0
   resolution: "webpack@npm:5.75.0"
   dependencies:


### PR DESCRIPTION
This PR corrects an issue where dependabot was not configured to update the version numbers listed in package.json when updating packages. This has been corrected and the version numbers have been updated.

In addition, this PR locks the version numbers of all dependencies to ensure that breaking changes of a dependency do not get added to a consuming project of this library.