### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,10 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
       timezone: "America/New_York"
       time: "06:00"
     target-branch: "develop"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     versioning-strategy: increase


### PR DESCRIPTION
This PR updates the dependabot configuration to run every Saturday morning at 6am with up to 20 requests. Daily requests are no longer necessary.